### PR TITLE
#26  - Fixing Column mix-up

### DIFF
--- a/tutorials/hortonworks/hello-hdp-an-introduction-to-hadoop/hello-hdp-section-6.md
+++ b/tutorials/hortonworks/hello-hdp-an-introduction-to-hadoop/hello-hdp-section-6.md
@@ -256,7 +256,7 @@ joined.collect.foreach(println)
 In this section we will associate a driver risk factor with every driver. Driver risk factor will be calculated by dividing total miles travelled by non-normal event occurrences.
 
 ~~~scala
-val risk_factor_spark=hiveContext.sql("select driverid, totmiles,occurance, totmiles/occurance riskfactor from joined")
+val risk_factor_spark=hiveContext.sql("select driverid, occurance, totmiles, totmiles/occurance riskfactor from joined")
 ~~~
 
 


### PR DESCRIPTION
- Fixes #26

Fixing a query in the spark lab which puts the columns in a query in the incorrect order.