### PR TITLE
NiFi Lab 0 Review

### DIFF
--- a/assets/realtime-event-processing/install-nifi.sh
+++ b/assets/realtime-event-processing/install-nifi.sh
@@ -35,5 +35,5 @@ cd \$HDF2/nifi
 echo 'Updating Run Configs'
 sed -i s/nifi.web.http.port=8080/nifi.web.http.port=6434/g conf/nifi.properties
 echo "NiFi is now installed on Sandbox at /root/hdf/\$HDF2/nifi"
-echo "Run NiFi on the sandbox with the command \"/root/hdf/\$HDF2/nifi/bin/nifi.sh run\""
+echo "Run NiFi on the sandbox with the command \"/root/hdf/\$HDF2/nifi/bin/nifi.sh start\""
 ENDSSH

--- a/assets/realtime-event-processing/install-nifi.sh
+++ b/assets/realtime-event-processing/install-nifi.sh
@@ -29,9 +29,11 @@ mv $HDF_FILE ./hdf
 cd hdf
 echo 'Extracting Archive'
 tar -xvf $HDF_FILE > /dev/null
+chown -R root:root \$HDF2
 cd \$HDF2/nifi
+
 echo 'Updating Run Configs'
 sed -i s/nifi.web.http.port=8080/nifi.web.http.port=6434/g conf/nifi.properties
-echo "NiFi now installed on Sandbox at /root/hdf/\$HDF2/nifi"
-echo "Run NiFi on the sandbox with the command \"bash /root/hdf/\$HDF2/nifi/bin/nifi.sh run\""
+echo "NiFi is now installed on Sandbox at /root/hdf/\$HDF2/nifi"
+echo "Run NiFi on the sandbox with the command \"/root/hdf/\$HDF2/nifi/bin/nifi.sh run\""
 ENDSSH

--- a/assets/realtime-event-processing/install-nifi.sh
+++ b/assets/realtime-event-processing/install-nifi.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 export HDF_ZIP=$1
 export HOST=$2
 export PORT=$3

--- a/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
+++ b/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
@@ -37,6 +37,19 @@ If you plan to install HDF on Hortonworks Sandbox, review the table, then procee
 
 > Note: **Host Name** values are unique for VMware & Azure Sandbox compared to the table. For VMware and VirtualBox, **Host Name** is located on welcome screen. For Azure, **Host Name** is located under **Public IP Address** on Sandbox Dashboard. For Azure users, the terminal **username** and **password** is one you created while deploying the sandbox on azure. For VMware and VirtualBox users, terminal password changes after first login.
 
+If it is your first time SSH'ing into the sandbox VM, it may prompt you to change the default 'hadoop' password. Please run this command and provide a stronger password:
+```
+ssh -p 2222 root@localhost
+root@localhost's password:
+You are required to change your password immediately (root enforced)
+Last login: Wed Jun 15 19:47:44 2016 from 10.0.2.2
+Changing password for root.
+(current) UNIX password:
+New password:
+Retype new password:
+[root@sandbox ~]#
+```
+
 ### 1.2 Plan to Install HDF 1.2 on Local Machine
 
 This section is important to read through if you want to install NiFi on your local machine. Refer to step 3 if you read this section.

--- a/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
+++ b/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
@@ -81,6 +81,7 @@ The following instructions will guide you through the NiFi installation process.
 ~~~
 cd
 curl -o install-nifi.sh https://raw.githubusercontent.com/hortonworks/tutorials/hdp/assets/realtime-event-processing/install-nifi.sh
+chmod +x ./install-nifi.sh
 ~~~
 
 2\. Open a browser. NiFi can be downloaded from [HDF Downloads Page](http://hortonworks.com/downloads/). There are two package options one for HDF TAR.GZ file tailored to Linux and ZIP file more compatible with Windows. Mac can use either option. For the tutorial, let's download the latest HDF TAR.GZ:

--- a/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
+++ b/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
@@ -188,6 +188,7 @@ Click the button that says **Port Forwarding**. Overwrite NiFi entry with the fo
 
 4\. Open NiFi at `http://sandbox.hortonworks.com:6434/nifi/`. You should be able to access it now. Wait 1 to 2 minutes for NiFi to load.
 
+> Note: if you haven't configured the `sandbox.hortonworks.com` alias in `/etc/hosts`, try the `http://localhost:6434/nifi` URL as well.
 
 ### 4.2 Forward Port with Azure GUI
 

--- a/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
+++ b/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
@@ -79,7 +79,7 @@ The following instructions will guide you through the NiFi installation process.
 1\. Open a terminal window (Mac and Linux) or git bash (Windows) on **local machine**. Download the **install-nifi.sh** file from the github repo. Copy & paste the following commands:
 
 ~~~
-cd ~
+cd
 curl -o install-nifi.sh https://raw.githubusercontent.com/hortonworks/tutorials/hdp/assets/realtime-event-processing/install-nifi.sh
 ~~~
 

--- a/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
+++ b/tutorials/hortonworks/learning-ropes-apache-nifi-lab-series/learning-ropes-nifi-lab0.md
@@ -98,7 +98,7 @@ install-nifi.sh {location-of-HDF-download} {sandbox-host} {ssh-port} {hdf-versio
 After you provide the file path location to HDF TAR.GZ file, sandbox hostname, ssh port number and HDF version, your command should look similar as follows:
 
 ~~~
-bash install-nifi.sh ~/Downloads/HDF-1.2.0.1-1.tar.gz localhost 2222 1.2.0.1-1
+./install-nifi.sh ~/Downloads/HDF-1.2.0.1-1.tar.gz localhost 2222 1.2.0.1-1
 ~~~
 
 > Note: You will be asked if you want to continue the download, type `yes`. You will also be asked twice for your ssh password to install NiFi on your Hortonworks Sandbox.


### PR DESCRIPTION
A number of changes:

- More idiomatic unix commands in scripts and docs
- Fixed ownership and permission of the HDF files
- Expanded docs on first-time SSH password change requirement
- Fixed script output to suggest nifi 'start' instead of 'run' (want to send to background)
- Added a tip for using http://localhost:6434/nifi , as we never mentioned how to configure sandbox aliases in this tutorial.