### PR TITLE
Remove backslash and have command on single line

### DIFF
--- a/tutorials/hortonworks/search-data-with-solr/tutorial.md
+++ b/tutorials/hortonworks/search-data-with-solr/tutorial.md
@@ -114,8 +114,7 @@ cp /opt/lucidworks-hdpsearch/solr/server/solr/solr.xml ~/solr-cores/core2
 ### [](#step-4---create-a-solr-collection-named-labs-with-2-shards-and-a-replication-factor-of-2)Step 4 – Create a Solr Collection named “labs” with 2 shards and a replication factor of 2
 
 ~~~
-/opt/lucidworks-hdpsearch/solr/bin/solr create -c labs \
--d /opt/lucidworks-hdpsearch/solr/server/solr/configsets/data_driven_schema_configs_hdfs/conf -n labs -s 2 -rf 2
+/opt/lucidworks-hdpsearch/solr/bin/solr create -c labs -d /opt/lucidworks-hdpsearch/solr/server/solr/configsets/data_driven_schema_configs_hdfs/conf -n labs -s 2 -rf 2
 ~~~
 
 ### [](#step-5---validate-that-the-labs-collection-got-created)Step 5 – Validate that the labs collection got created


### PR DESCRIPTION
Fixes Issue # .

This pull request aims to addres:
Although the Github markdown processor correctly generate the backslash in the output, on the website it's not included (http://hortonworks.com/hadoop-tutorial/searching-data-solr/) . If you copy and paste the statement, it's executed as two commands instead of one.