### PR TITLE
HDP 2.5

### DIFF
--- a/tutorials/hortonworks/hortonworks-sandbox-hdp2.5-guide/install_guide_docker.md
+++ b/tutorials/hortonworks/hortonworks-sandbox-hdp2.5-guide/install_guide_docker.md
@@ -74,7 +74,227 @@ You can now connect to the sandbox tutorials page at http://localhost:8888
 
 ![splash_screen.png](/assets/hortonworks-sandbox-hdp2.5-guide/splash_screen.png)
 
-## Run notes for non-linux users:
+## Run notes for Mac users:
+
+1. Ensure the Docker daemon is running.  You can verify by typing:
+
+```
+$ docker images
+```
+
+You should see something similar to this:
+
+```
+$ docker images
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+```
+
+If your Docker daemon is not running, you may see the following:
+
+```
+$ docker images
+Error response from daemon: Bad response from Docker engine
+```
+
+2. Before loading the Docker image, you need to uncompress it:
+
+```
+$ gunzip HDP_2.5_docker.tar.gz
+```
+
+3. Load the Hortonworks sandbox image into Docker:
+
+```
+$ docker load < HDP_2.5_docker.tar
+```
+
+You should see something similar to this:
+
+```
+$ docker load < HDP_2.5_docker.tar
+b1b065555b8a: Loading layer [==================================================>] 202.2 MB/202.2 MB
+0b547722f59f: Loading layer [==================================================>] 13.84 GB/13.84 GB
+99d7327952e0: Loading layer [==================================================>] 234.8 MB/234.8 MB
+294b1c0e07bd: Loading layer [==================================================>] 207.5 MB/207.5 MB
+fd5c10f2f1a1: Loading layer [==================================================>] 387.6 kB/387.6 kB
+6852ef70321d: Loading layer [==================================================>]   163 MB/163 MB
+517f170bbf7f: Loading layer [==================================================>] 20.98 MB/20.98 MB
+665edb80fc91: Loading layer [==================================================>] 337.4 kB/337.4 kB
+Loaded image: sandbox:latest
+```
+
+4. Verify the image was successfully imported:
+
+```
+$ docker images
+```
+
+You should see something similar to this:
+
+```
+$ docker images
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+sandbox             latest              fc813bdc4bdd        3 days ago          14.57 GB
+```
+
+5. Start the container:
+The first time you start the container, you need to create it via the run command.  The run command both creates and starts the container.
+
+```
+docker run -v hadoop:/hadoop --name sandbox --hostname "sandbox.hortonworks.com" --privileged -d \
+-p 6080:6080 \
+-p 9090:9090 \
+-p 9000:9000 \
+-p 8000:8000 \
+-p 8020:8020 \
+-p 42111:42111 \
+-p 10500:10500 \
+-p 16030:16030 \
+-p 8042:8042 \
+-p 8040:8040 \
+-p 2100:2100 \
+-p 4200:4200 \
+-p 4040:4040 \
+-p 8050:8050 \
+-p 9996:9996 \
+-p 9995:9995 \
+-p 8080:8080 \
+-p 8088:8088 \
+-p 8886:8886 \
+-p 8889:8889 \
+-p 8443:8443 \
+-p 8744:8744 \
+-p 8888:8888 \
+-p 8188:8188 \
+-p 8983:8983 \
+-p 1000:1000 \
+-p 1100:1100 \
+-p 11000:11000 \
+-p 10001:10001 \
+-p 15000:15000 \
+-p 10000:10000 \
+-p 8993:8993 \
+-p 1988:1988 \
+-p 5007:5007 \
+-p 50070:50070 \
+-p 19888:19888 \
+-p 16010:16010 \
+-p 50111:50111 \
+-p 50075:50075 \
+-p 50095:50095 \
+-p 18080:18080 \
+-p 60000:60000 \
+-p 8090:8090 \
+-p 8091:8091 \
+-p 8005:8005 \
+-p 8086:8086 \
+-p 8082:8082 \
+-p 60080:60080 \
+-p 8765:8765 \
+-p 5011:5011 \
+-p 6001:6001 \
+-p 6003:6003 \
+-p 6008:6008 \
+-p 1220:1220 \
+-p 21000:21000 \
+-p 6188:6188 \
+-p 61888:61888 \
+-p 2222:22 \
+sandbox /usr/sbin/sshd -D
+```
+
+Once the container is created and running, Docker will display a CONTAINER ID for the container.  You should see something similar to this:
+
+```
+fe57fe79f795905daa50191f92ad1f589c91043a30f7153899213a0cadaa5631
+```
+
+For all future container starts, you only need to run the docker start command:
+
+```
+$ docker start sandbox
+```
+
+6. Verify the container is running:
+
+```
+$ docker ps
+```
+
+You should see something similar to this:
+
+```
+$ docker ps
+CONTAINER ID        IMAGE               COMMAND               CREATED             STATUS              PORTS             NAMES
+
+85d7ec7201d8        sandbox             "/usr/sbin/sshd -D"   31 seconds ago      Up 27 seconds       0.0.0.0:1000->1000/tcp, 0.0.0.0:1100->1100/tcp, 0.0.0.0:1220->1220/tcp, 0.0.0.0:1988->1988/tcp, 0.0.0.0:2100->2100/tcp, 0.0.0.0:4040->4040/tcp, 0.0.0.0:4200->4200/tcp, 0.0.0.0:5007->5007/tcp, 0.0.0.0:5011->5011/tcp, 0.0.0.0:6001->6001/tcp, 0.0.0.0:6003->6003/tcp, 0.0.0.0:6008->6008/tcp, 0.0.0.0:6080->6080/tcp, 0.0.0.0:6188->6188/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8005->8005/tcp, 0.0.0.0:8020->8020/tcp, 0.0.0.0:8040->8040/tcp, 0.0.0.0:8042->8042/tcp, 0.0.0.0:8050->8050/tcp, 0.0.0.0:8080->8080/tcp, 0.0.0.0:8082->8082/tcp, 0.0.0.0:8086->8086/tcp, 0.0.0.0:8088->8088/tcp, 0.0.0.0:8090-8091->8090-8091/tcp, 0.0.0.0:8188->8188/tcp, 0.0.0.0:8443->8443/tcp, 0.0.0.0:8744->8744/tcp, 0.0.0.0:8765->8765/tcp, 0.0.0.0:8886->8886/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, 0.0.0.0:8983->8983/tcp, 0.0.0.0:8993->8993/tcp, 0.0.0.0:9000->9000/tcp, 0.0.0.0:9090->9090/tcp, 0.0.0.0:9995-9996->9995-9996/tcp, 0.0.0.0:10000-10001->10000-10001/tcp, 0.0.0.0:10500->10500/tcp, 0.0.0.0:11000->11000/tcp, 0.0.0.0:15000->15000/tcp, 0.0.0.0:16010->16010/tcp, 0.0.0.0:16030->16030/tcp, 0.0.0.0:18080->18080/tcp, 0.0.0.0:19888->19888/tcp, 0.0.0.0:21000->21000/tcp, 0.0.0.0:42111->42111/tcp, 0.0.0.0:50070->50070/tcp, 0.0.0.0:50075->50075/tcp, 0.0.0.0:50095->50095/tcp, 0.0.0.0:50111->50111/tcp, 0.0.0.0:60000->60000/tcp, 0.0.0.0:60080->60080/tcp, 0.0.0.0:61888->61888/tcp, 0.0.0.0:2222->22/tcp   sandbox
+```
+
+Notice the CONTAINER ID is the shortened version of the ID displayed when you ran the run command.
+
+
+7. To stop the container
+Once the container is running, you stop it using the following command:
+
+```
+$ docker stop sandbox
+```
+
+8. To connect to the container
+You connect to the container via ssh using the following command:
+
+```
+$ ssh -p 2222 root@localhost
+```
+
+The first time you log into the container, you will be prompted to change the root password.  The root password for the container is `hadoop`.
+
+9. Start sandbox services
+The Ambari and HDP services do not start automatically when you start the Docker container.  You need to start the processes with a script.
+
+```
+$ ssh -p 2222 root@localhost
+$ /etc/init.d/startup_script start
+```
+
+You should see something similar to this (you can ignore any warnings):
+
+```
+# /etc/init.d/startup_script start
+Starting tutorials...                                      [  Ok  ]
+Starting startup_script...
+Starting HDP ...
+Starting mysql                                            [  OK  ]
+Starting Flume                                            [  OK  ]
+Starting Postgre SQL                                      [  OK  ]
+Starting Ranger-admin                                     [  OK  ]
+Starting name node                                        [  OK  ]
+Starting Ranger-usersync                                  [  OK  ]
+Starting data node                                        [  OK  ]
+Starting Zookeeper nodes                                  [  OK  ]
+Starting Oozie                                            [  OK  ]
+Starting Ambari server                                    [  OK  ]
+Starting NFS portmap                                      [  OK  ]
+Starting Hdfs nfs                                         [  OK  ]
+Starting Hive server                                      [  OK  ]
+Starting Hiveserver2                                      [  OK  ]
+Starting Ambari agent                                     [  OK  ]
+Starting Node manager                                     [  OK  ]
+Starting Yarn history server                              [  OK  ]
+Starting Resource manager                                 [  OK  ]
+Starting Webhcat server                                   [  OK  ]
+Starting Spark                                            [  OK  ]
+Starting Mapred history server                            [  OK  ]
+Starting Zeppelin                                         [  OK  ]
+Safe mode is OFF
+Starting sandbox...
+./startup_script: line 97: /proc/sys/kernel/hung_task_timeout_secs: No such file or directory
+Starting shellinaboxd:                                     [  OK  ]
+```
+
+10. You can now connect to your machine at http://localhost:8888
+
+## Run notes for non-linux/mac users:
 
 In order to launch the sandbox in a non-linux environment, proceed to import the sandbox.tar image as instructed by the version of docker you are using.  
 

--- a/tutorials/hortonworks/hortonworks-sandbox-hdp2.5-guide/release_notes.md
+++ b/tutorials/hortonworks/hortonworks-sandbox-hdp2.5-guide/release_notes.md
@@ -247,7 +247,7 @@ postgresql-8.4.20-6.el6.x86_64
 postgresql-libs-8.4.20-6.el6.x86_64  
 postgresql-server-8.4.20-6.el6.x86_64  
 
-**HDP Services Started Automatically on Startup**  
+##HDP Services Started Automatically on Startup*
 When the virtual machine is booted up, the following services are started. If not specified, assume all are java processes.  The users that launch the process are the corresponding names of the component.  The processes are listed with their main class.  
 
 **Ambari**  
@@ -296,8 +296,8 @@ QuorumPeerMain - org.apache.zookeeper.server.quorum.QuorumPeerMain
 **Zeppelin**    
 ZeppelinServer - org.apache.zeppelin.server.ZeppelinServer  
 
-**HDP Services not started automatically**  
-In order to utilize the functionality of these services, they need to be turned on and require more memory to be added to the virtual machine.  
+##HDP Services NOT Started Automatically on Startup*
+Because of the limited resources avaialble in the sandbox virtual machine environment, the following services are in maintenance mode and will not automatically start.  To fully use these services, you must allocate more memory to the sandbox virtual machine.  If you want these services to automatically start, turn off maintenance mode.  The processes are listed with their main class.  
 
 **Ambari Infra**  
 **Ambari Metrics**  
@@ -337,20 +337,3 @@ nimbus - backtype.storm.daemon.nimbus
 logviewer - backtype.storm.daemon.logviewer  
 core - backtype.storm.ui.core  
 drpc -  backtype.storm.daemon.drpc  
-
-As Designed  
-The following are Ambari settings that one should be aware of.  
-
-1\. By default Ambari Metrics service is off.  
-2\.  Maintenance Mode is on for  
-* HDFS  
-* HBase  
-* Falcon  
-* Storm  
-* Ambari Metrics  
-* Ambari Infra  
-* Atlas  
-* Kafka  
-* Knox  
-* Spark  
-* Spark2  

--- a/tutorials/hortonworks/hortonworks-sandbox-hdp2.5-guide/start_sandbox.sh
+++ b/tutorials/hortonworks/hortonworks-sandbox-hdp2.5-guide/start_sandbox.sh
@@ -62,6 +62,7 @@ docker run -v hadoop:/hadoop --name sandbox --hostname "sandbox.hortonworks.com"
 -p 1220:1220 \
 -p 21000:21000 \
 -p 6188:6188 \
+-p 61888:61888 \
 -p 2222:22 \
 sandbox /usr/sbin/sshd -D
 fi


### PR DESCRIPTION
This pull request aims to address:
- Add more clarity about services in maintenance mode in the sandbox by using header fonts and adding information.
- Add port 61888 to docker container for LogSearch. If you add the LogSearch service via Ambari, it uses port 61888 and the port is not exposed by default.