### PR TITLE
incorrect command for ssh example

### DIFF
--- a/tutorials/hortonworks/hello-hdp-an-introduction-to-hadoop/hello-hdp-section-4.md
+++ b/tutorials/hortonworks/hello-hdp-an-introduction-to-hadoop/hello-hdp-section-4.md
@@ -222,8 +222,10 @@ i.  Local Sandbox VM
     Open up shell in the box to ssh into HDP with
 
     ~~~
-    ssh maria_dev@127.0.0.1 -p 2222 maria_dev
+    ssh maria_dev@127.0.0.1 -p 2222
     ~~~
+
+    Enter the default password "maria_dev"
 
 ii.  `su hive`  
 


### PR DESCRIPTION
Issuing the original command seems incorrect. Not sure why the password was tacked onto the end. Perhaps you meant:

```
sshpass -p 'maria_dev' ssh maria_dev@127.0.0.1 -p 2222
```
Original results
```
mikeyd@archboxmtd ~/downloads $ ssh maria_dev@127.0.0.1 -p 2222 maria_dev
maria_dev@127.0.0.1's password: 
bash: maria_dev: command not found
mikeyd@archboxmtd ~/downloads  $ ssh maria_dev@127.0.0.1 -p 2222
maria_dev@127.0.0.1's password:
```

This change will merely prompt the user for the password, as normal behavior. Most systems I have been on, do not  install `sshpass` by default.

This pull request aims to address: incorrect ssh command in Lab2